### PR TITLE
Make output of idf.py build available for other workflow steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ description: "This action build your firmware directly in github using Espressif
 branding:
   color: blue
   icon: check
+outputs:
+  build_output:
+    description: "Output of the idf.py build command."
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,5 @@ set -e
 
 . $IDF_PATH/export.sh
 
-idf.py build
+build_output=$(idf.py build)
+echo "::set-output name=build_output::$build_output"


### PR DESCRIPTION
This PR captures the output of the `idf.py build` command and makes it available as an output for other workflow steps. This is mandatory for a custom `flash.sh` to be delivered with a firmware generated by the [tbd-cloud-compiler](https://fxwiegand.github.io/tbd-cloud-compiler/). Using the output of the esp-idf-action would work like this in a workflow:

```yaml
- name: Build binaries
  id: idf_build
  uses: ctag-fh-kiel/esp-idf-action@1

- name: Print output of build command
  run: echo "${{ steps.idf_build.outputs.build_output }}"
```