### PR TITLE
Fix output of idf.py build

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,7 @@ set -e
 . $IDF_PATH/export.sh
 
 build_output=$(idf.py build)
+build_output="${build_output//'%'/'%25'}"
+build_output="${build_output//$'\n'/'%0A'}"
+build_output="${build_output//$'\r'/'%0D'}"
 echo "::set-output name=build_output::$build_output"


### PR DESCRIPTION
It seems like outputs of GitHub Actions steps/jobs do not support multiline strings as explained [here](https://trstringer.com/github-actions-multiline-strings/). This PR simply fixes this by substituting the `%`, `\n`, and `\r` characters as suggested in the linked article.